### PR TITLE
Fix Picmo style leak

### DIFF
--- a/dist/module.json
+++ b/dist/module.json
@@ -17,10 +17,6 @@
       "discord":"YourFavouriteOreo#6798"
     },
     {
-      "name": "Asinphi",
-      "url":"https://github.com/Asinphi"
-    },
-    {
       "name": "Blackcloud",
       "url": "https://github.com/Blackcloud010",
       "discord": "Blackcloud010#5426"

--- a/dist/styles/module.css
+++ b/dist/styles/module.css
@@ -1,3 +1,12 @@
+/* Better position the emoji picker in PopOut! chat log */
+#chat-popout .picmo__picker {
+  right: 10px;
+}
+
+#chat-popout .picmo__closeButton {
+  left: 0;
+}
+
 #emojipleter {
   position: absolute;
   z-index: 200;
@@ -121,20 +130,20 @@ img.emoji.emoji-large, svg.emoji.emoji-large {
   filter: invert(100%);
 }
 
-.popupContainer {
+.picmo__popupContainer {
   z-index: 1000; /* So it appears above popped-out chat logs */
 }
 
-.picmo-picker { /* Make more compact */
+.picmo__picker { /* Make more compact */
   gap: 2px;
 }
 
-.picmo-picker .header {
+.picmo__picker .picmo__header {
   padding-bottom: 0;
   gap: 2px;
 }
 
-.picmo-picker .emojiCategory .categoryName {
+.picmo__picker .emojiCategory .categoryName {
   font-family: 'Signika', sans-serif;
 }
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@picmo/popup-picker": "^5.7.2",
     "@picmo/renderer-twemoji": "^5.7.2",
     "axios": "^0.21.1",
-    "picmo": "^5.7.2",
+    "picmo": "^5.8.1",
     "twemoji-parser": "^14.0.0"
   }
 }

--- a/src/chatreactions.ts
+++ b/src/chatreactions.ts
@@ -326,6 +326,7 @@ function createPicker(rootElement: HTMLElement = document.body) {
   }, {
     showCloseButton: true,
     onPositionLost: "close",
+    position: rootElement == document.body ? "auto" : "left",
   });
   newPicker.addEventListener("emoji:select", onEmojiInput);
   return newPicker;

--- a/src/chatreactions.ts
+++ b/src/chatreactions.ts
@@ -286,7 +286,7 @@ Hooks.once("init", async () => {
     )}`,
     "--hover-background-color": "#e7f3f8",
   };
-  $("head").append(`<style class="emoji-picker__styles">.picmo-picker {${Object.entries(pickerCssRules).map(([key, value]) => `${key}: ${value};`).join("\n")}}</style>`);
+  $("head").append(`<style class="emoji-picker__styles">.picmo__picker {${Object.entries(pickerCssRules).map(([key, value]) => `${key}: ${value};`).join("\n")}}</style>`);
 });
 
 function onEmojiInput(selection) {

--- a/static/styles/module.css
+++ b/static/styles/module.css
@@ -121,20 +121,20 @@ img.emoji.emoji-large, svg.emoji.emoji-large {
   filter: invert(100%);
 }
 
-.popupContainer {
+.picmo__popupContainer {
   z-index: 1000; /* So it appears above popped-out chat logs */
 }
 
-.picmo-picker { /* Make more compact */
+.picmo__picker { /* Make more compact */
   gap: 2px;
 }
 
-.picmo-picker .header {
+.picmo__picker .picmo__header {
   padding-bottom: 0;
   gap: 2px;
 }
 
-.picmo-picker .emojiCategory .categoryName {
+.picmo__picker .emojiCategory .categoryName {
   font-family: 'Signika', sans-serif;
 }
 

--- a/static/styles/module.css
+++ b/static/styles/module.css
@@ -1,3 +1,12 @@
+/* Better position the emoji picker in PopOut! chat log */
+#chat-popout .picmo__picker {
+  right: 10px;
+}
+
+#chat-popout .picmo__closeButton {
+  left: 0;
+}
+
 #emojipleter {
   position: absolute;
   z-index: 200;


### PR DESCRIPTION
In previous versions, Picmo emoji picker's styles leaked into Foundry because its CSS class names were too generic, causing issues like #19. These were fixed in later versions, so this pull request updates the Picmo library and makes some changes to be compatible with the new Picmo.

It also improves the position of the emoji picker popout in PopOut! module windows, which were previously far to the right so the close button was hard to click.